### PR TITLE
Fixed indentation on Python code sample

### DIFF
--- a/lab/src/weather/README.md
+++ b/lab/src/weather/README.md
@@ -188,13 +188,13 @@ do its conversion. We can create a new span whenever this function is called:
 
     ```python
     def convert_daylight_duration(daylight_duration):
-    with tracer.start_as_current_span("convert_daylight") as span:
-        span.set_attribute("daylight_duration", daylight_duration)
-        hours = int(daylight_duration // 3600)
-        minutes = int ((daylight_duration % 3600) // 60)
+        with tracer.start_as_current_span("convert_daylight") as span:
+            span.set_attribute("daylight_duration", daylight_duration)
+            hours = int(daylight_duration // 3600)
+            minutes = int ((daylight_duration % 3600) // 60)
 
-        span.set_status(trace.Status(trace.StatusCode.OK))
-        return f"{hours}h {minutes}min"
+            span.set_status(trace.Status(trace.StatusCode.OK))
+            return f"{hours}h {minutes}min"
     ```
 
     `with tracer.start_as_current_span("convert_daylight") as span` will create a span


### PR DESCRIPTION
After making this change (copying and pasting the code without thinking) the lab-weather container was not starting with error:

2025-01-25 19:54:32   File "/usr/src/app/app.py", line 102
2025-01-25 19:54:32     with tracer.start_as_current_span("convert_daylight") as span:
2025-01-25 19:54:32     ^^^^
2025-01-25 19:54:32 IndentationError: expected an indented block after function definition on line 101

Ther was a small indentation mistake on th readme file